### PR TITLE
Replace print statements with logging statements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog for pytest-crate
 Unreleased
 ==========
 
+- Replace ``print`` statements with ``logging.debug`` statements so that
+  retrieving the fixture does not produce output that is captured in doctests.
+  This may break existing usages of the fixture in doctests in case the output
+  of the ``getfixture`` method was matched.
+
 2019/04/05 0.2.0
 ================
 

--- a/pytest_crate/plugin.py
+++ b/pytest_crate/plugin.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import shutil
 import string
@@ -11,6 +12,8 @@ from crate.client import connect
 from crate.client.cursor import Cursor
 
 __all__ = ["crate"]
+
+logger = logging.getLogger(__name__)
 
 
 class CrateLayer:
@@ -35,7 +38,7 @@ class CrateLayer:
         self._stop()
 
     def _start(self) -> None:
-        print(f"Starting {self} ...")
+        logger.debug(f"Starting {self} ...")
         self.tmp = tempfile.mkdtemp()
         settings = {
             "cluster.name": self.name,
@@ -48,13 +51,13 @@ class CrateLayer:
             crate_dir=self.crate_dir, keep_data=False, settings=settings, env=env
         )
         self.node.start()
-        print(f"{self} started")
+        logger.debug(f"{self} started")
 
     def _stop(self) -> None:
-        print(f"Stopping {self} ...")
+        logger.debug(f"Stopping {self} ...")
         self.node.stop()
         shutil.rmtree(self.tmp, ignore_errors=True)
-        print(f"{self} stopped")
+        logger.debug(f"{self} stopped")
 
     def dsn(self) -> str:
         return self.node.http_url

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ multi_line_output = 3
 not_skip = __init__.py
 
 [tool:pytest]
-addopts = --flake8 --mypy --mypy-ignore-missing-imports --isort --crate-version latest-testing
+addopts = --flake8 --mypy --mypy-ignore-missing-imports --isort --crate-version latest-testing --doctest-glob="tests/*.rst"
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
 flake8-max-line-length = 88
 flake8-ignore = E203 W503


### PR DESCRIPTION
This commit solves the problem, that when running doctests and
retrieving the `crate` fixture with `getfixture`, it produces output
that needs to be matched in the doctest.